### PR TITLE
Item & Location Groups, Speedrun Trick Support, and Some Documentation Improvements

### DIFF
--- a/worlds/sly1/.gitignore
+++ b/worlds/sly1/.gitignore
@@ -1,0 +1,1 @@
+Item and Location Groups.txt

--- a/worlds/sly1/Callbacks.py
+++ b/worlds/sly1/Callbacks.py
@@ -159,33 +159,33 @@ async def handle_checks(ctx: 'Sly1Context') -> None:
     for episode_index, (episode_name, level_list) in enumerate(LEVELS.items()):
         for level_index, level_name in enumerate(level_list):
             if ctx.level_keys[episode_index][level_index]:
-                location_name = f"{level_name} Key"
+                location_name = f"{level_name}: Key"
                 if location_name in location_table:
                     location_code = location_table[location_name].ap_code
                     if location_code not in ctx.locations_checked:
                         ctx.locations_checked.add(location_code)
                 # Minigame Caches
-                minigame_name = level_name + " Key"
+                minigame_name = level_name + ": Key"
                 if minigame_name in minigame_locations:
                     for i in range(1, 11):
                         location_code = minigame_locations[minigame_name].ap_code + i
                         if location_code not in ctx.locations_checked:
                             ctx.locations_checked.add(location_code)
                 # Key Caches
-                if level_name + " Key" in KEY_LOCATION_NAMES:
-                    key_index = KEY_LOCATION_NAMES.index(level_name + " Key")
+                if level_name + ": Key" in KEY_LOCATION_NAMES:
+                    key_index = KEY_LOCATION_NAMES.index(level_name + ": Key")
                     for i in range(10):
                         location_code = KEY_CACHE_BASE + (key_index * 10) + i
                         if location_code in ctx.server_locations and location_code not in ctx.locations_checked:
                             ctx.locations_checked.add(location_code)
             if ctx.vaults[episode_index][level_index]:
-                location_name = f"{level_name} Vault"
+                location_name = f"{level_name}: Vault"
                 if location_name in location_table:
                     location_code = location_table[location_name].ap_code
                     if location_code not in ctx.locations_checked:
                         ctx.locations_checked.add(location_code)
             if ctx.hourglasses[episode_index][level_index]:
-                location_name = f"{level_name} Hourglass"
+                location_name = f"{level_name}: Hourglass"
                 if location_name in location_table:
                     location_code = location_table[location_name].ap_code
                     if location_code not in ctx.locations_checked:
@@ -294,7 +294,7 @@ async def handle_received(ctx: 'Sly1Context') -> None:
         if 10020030 <= item.ap_code <= 10020048:
             for name, data in bottles.items():
                 if data.ap_code == item.ap_code:
-                    bottle_level = name.replace(" Bottle(s)", "")
+                    bottle_level = name.replace(": Bottle(s)", "")
 
                     for episode_index, (world, levels) in enumerate(LEVELS.items()):
                         if bottle_level in levels:
@@ -326,10 +326,10 @@ def save_state(seed, new_state):
 
 def get_blueprint(episode: int) -> Optional[str]:
     blueprint_mapping = {
-        Sly1Episode.Tide_of_Terror: "ToT Blueprints",
-        Sly1Episode.Sunset_Snake_Eyes: "SSE Blueprints",
-        Sly1Episode.Vicious_Voodoo: "VV Blueprints",
-        Sly1Episode.Fire_in_the_Sky: "FitS Blueprints",
+        Sly1Episode.Tide_of_Terror: "Tide of Terror: Blueprints",
+        Sly1Episode.Sunset_Snake_Eyes: "Sunset Snake Eyes: Blueprints",
+        Sly1Episode.Vicious_Voodoo: "Vicious Voodoo: Blueprints",
+        Sly1Episode.Fire_in_the_Sky: "Fire in the Sky: Blueprints",
     }
     return blueprint_mapping.get(Sly1Episode(episode))
 

--- a/worlds/sly1/Items.py
+++ b/worlds/sly1/Items.py
@@ -1,6 +1,6 @@
 import logging
 from BaseClasses import Item, ItemClassification
-from worlds.sly1.Types import ItemData, Sly1Item, EpisodeType, episode_type_to_name, episode_type_to_shortened_name
+from worlds.sly1.Types import ItemData, Sly1Item, EpisodeType, episode_type_to_unlock
 from worlds.sly1.Locations import get_total_locations, get_bundle_amount_for_level, did_avoid_early_bk, hourglasses_roll, \
     did_include_hourglasses
 from typing import List, Dict, TYPE_CHECKING
@@ -14,10 +14,11 @@ def create_itempool(world: "Sly1World") -> List[Item]:
 
     # Determine if this player has AvoidEarlyBK enabled
     need_to_modify_item_pool = did_avoid_early_bk(world)
-    starting_episode = episode_type_to_name[EpisodeType(world.options.StartingEpisode)]
-    starting_episode_short = episode_type_to_shortened_name[EpisodeType(world.options.StartingEpisode)]
-    if starting_episode == "All" and need_to_modify_item_pool:
-        starting_episode = world.random_episode
+    starting_episode_unlock = episode_type_to_unlock[EpisodeType(world.options.StartingEpisode)]
+    starting_episode_name = starting_episode_unlock.replace(": Episode Unlock", "")
+
+    if starting_episode_name == "All" and need_to_modify_item_pool:
+        starting_episode_name = world.random_episode
 
     # Create a local copy of item_table to modify only for the current player
     # We won't modify the global item_table directly
@@ -25,7 +26,7 @@ def create_itempool(world: "Sly1World") -> List[Item]:
 
     # If AvoidEarlyBK is enabled, adjust the key count for the starting episode
     if need_to_modify_item_pool:
-        starting_key_name = f"{starting_episode_short} Key"
+        starting_key_name = f"{starting_episode_name}: Key"
         if starting_key_name in final_item_table:
             starting_key = final_item_table[starting_key_name]
             final_item_table[starting_key_name] = starting_key._replace(count=starting_key.count - 1)
@@ -37,9 +38,9 @@ def create_itempool(world: "Sly1World") -> List[Item]:
                 final_item_table[key] = item._replace(classification=ItemClassification.progression)
 
     # Create episodes except for the starting episode as items
-    if not starting_episode == "All":
+    if not starting_episode_name == "All":
         for episode in sly_episodes.keys():
-            if starting_episode == episode:
+            if starting_episode_unlock == episode:
                 continue
             else:
                 itempool.append(create_item(world, episode))
@@ -62,7 +63,7 @@ def create_itempool(world: "Sly1World") -> List[Item]:
             world.options.ItemCluesanityBundleSize.value = location_bundle_size
             item_bundle_size = location_bundle_size
         for name, data in bottles.items():
-            bundle_amount = get_bundle_amount_for_level(name.rsplit(' ', 1)[0], item_bundle_size)
+            bundle_amount = get_bundle_amount_for_level(name.split(':')[0], item_bundle_size)
             itempool += create_multiple_items(world, name, bundle_amount, data.classification)
 
     # Create pages for page hunt
@@ -147,16 +148,16 @@ sly_items = {
     "Hacking": ItemData(10020009, ItemClassification.useful),
 
     # Blueprints
-    "ToT Blueprints": ItemData(10020011, ItemClassification.useful),
-    "SSE Blueprints": ItemData(10020012, ItemClassification.useful),
-    "VV Blueprints": ItemData(10020013, ItemClassification.useful),
-    "FitS Blueprints": ItemData(10020014, ItemClassification.useful),
+    "Tide of Terror: Blueprints": ItemData(10020011, ItemClassification.useful),
+    "Sunset Snake Eyes: Blueprints": ItemData(10020012, ItemClassification.useful),
+    "Vicious Voodoo: Blueprints": ItemData(10020013, ItemClassification.useful),
+    "Fire in the Sky: Blueprints": ItemData(10020014, ItemClassification.useful),
 
     # Keys
-    "ToT Key": ItemData(10020015, ItemClassification.progression, 7),
-    "SSE Key": ItemData(10020016, ItemClassification.progression, 7),
-    "VV Key": ItemData(10020017, ItemClassification.progression, 7),
-    "FitS Key": ItemData(10020018, ItemClassification.progression, 7),
+    "Tide of Terror: Key": ItemData(10020015, ItemClassification.progression, 7),
+    "Sunset Snake Eyes: Key": ItemData(10020016, ItemClassification.progression, 7),
+    "Vicious Voodoo: Key": ItemData(10020017, ItemClassification.progression, 7),
+    "Fire in the Sky: Key": ItemData(10020018, ItemClassification.progression, 7),
 
     # Page Hunt
     "Thievius Raccoonus Page": ItemData(10020049, ItemClassification.progression, 0),
@@ -166,35 +167,35 @@ sly_items = {
 }
 
 sly_episodes = {
-    "Tide of Terror": ItemData(10020021, ItemClassification.progression, 0),
-    "Sunset Snake Eyes": ItemData(10020022, ItemClassification.progression, 0),
-    "Vicious Voodoo": ItemData(10020023, ItemClassification.progression, 0),
-    "Fire in the Sky": ItemData(10020024, ItemClassification.progression, 0),
+    "Tide of Terror: Episode Unlock": ItemData(10020021, ItemClassification.progression, 0),
+    "Sunset Snake Eyes: Episode Unlock": ItemData(10020022, ItemClassification.progression, 0),
+    "Vicious Voodoo: Episode Unlock": ItemData(10020023, ItemClassification.progression, 0),
+    "Fire in the Sky: Episode Unlock": ItemData(10020024, ItemClassification.progression, 0),
 }
 
 bottles = {
-    "Stealthy Approach Bottle(s)": ItemData(10020030, ItemClassification.progression, 0),
-    "Into the Machine Bottle(s)": ItemData(10020031, ItemClassification.progression, 0),
-    "High Class Heist Bottle(s)": ItemData(10020032, ItemClassification.progression, 0),
-    "Fire Down Below Bottle(s)": ItemData(10020033, ItemClassification.progression, 0),
-    "Cunning Disguise Bottle(s)": ItemData(10020034, ItemClassification.progression, 0),
-    "Gunboat Graveyard Bottle(s)": ItemData(10020035, ItemClassification.progression, 0),
+    "Stealthy Approach: Bottle(s)": ItemData(10020030, ItemClassification.progression, 0),
+    "Into the Machine: Bottle(s)": ItemData(10020031, ItemClassification.progression, 0),
+    "High Class Heist: Bottle(s)": ItemData(10020032, ItemClassification.progression, 0),
+    "Fire Down Below: Bottle(s)": ItemData(10020033, ItemClassification.progression, 0),
+    "Cunning Disguise: Bottle(s)": ItemData(10020034, ItemClassification.progression, 0),
+    "Gunboat Graveyard: Bottle(s)": ItemData(10020035, ItemClassification.progression, 0),
 
-    "Rocky Start Bottle(s)": ItemData(10020036, ItemClassification.progression, 0),
-    "Boneyard Casino Bottle(s)": ItemData(10020037, ItemClassification.progression, 0),
-    "Straight to the Top Bottle(s)": ItemData(10020038, ItemClassification.progression, 0),
-    "Two to Tango Bottle(s)": ItemData(10020039, ItemClassification.progression, 0),
-    "Back Alley Heist Bottle(s)": ItemData(10020040, ItemClassification.progression, 0),
+    "Rocky Start: Bottle(s)": ItemData(10020036, ItemClassification.progression, 0),
+    "Boneyard Casino: Bottle(s)": ItemData(10020037, ItemClassification.progression, 0),
+    "Straight to the Top: Bottle(s)": ItemData(10020038, ItemClassification.progression, 0),
+    "Two to Tango: Bottle(s)": ItemData(10020039, ItemClassification.progression, 0),
+    "Back Alley Heist: Bottle(s)": ItemData(10020040, ItemClassification.progression, 0),
 
-    "Dread Swamp Path Bottle(s)": ItemData(10020041, ItemClassification.progression, 0),
-    "Lair of the Beast Bottle(s)": ItemData(10020042, ItemClassification.progression, 0),
-    "Grave Undertaking Bottle(s)": ItemData(10020043, ItemClassification.progression, 0),
-    "Descent into Danger Bottle(s)": ItemData(10020044, ItemClassification.progression, 0),
+    "Dread Swamp Path: Bottle(s)": ItemData(10020041, ItemClassification.progression, 0),
+    "Lair of the Beast: Bottle(s)": ItemData(10020042, ItemClassification.progression, 0),
+    "Grave Undertaking: Bottle(s)": ItemData(10020043, ItemClassification.progression, 0),
+    "Descent into Danger: Bottle(s)": ItemData(10020044, ItemClassification.progression, 0),
 
-    "Perilous Ascent Bottle(s)": ItemData(10020045, ItemClassification.progression, 0),
-    "Flaming Temple of Flame Bottle(s)": ItemData(10020046, ItemClassification.progression, 0),
-    "Unseen Foe Bottle(s)": ItemData(10020047, ItemClassification.progression, 0),
-    "Duel by the Dragon Bottle(s)": ItemData(10020048, ItemClassification.progression, 0)
+    "Perilous Ascent: Bottle(s)": ItemData(10020045, ItemClassification.progression, 0),
+    "Flaming Temple of Flame: Bottle(s)": ItemData(10020046, ItemClassification.progression, 0),
+    "Unseen Foe: Bottle(s)": ItemData(10020047, ItemClassification.progression, 0),
+    "Duel by the Dragon: Bottle(s)": ItemData(10020048, ItemClassification.progression, 0)
 }
 
 junk_items = {
@@ -234,3 +235,11 @@ def from_id(item_id: int) -> ItemData:
         raise ValueError(f"No item data for item id '{item_id}'")
     assert len(matching) < 2, f"Multiple item data with id '{item_id}'. Please report."
     return matching[0]
+
+# used in 2 ways for item groups. Keys serve as episode lookup and level lists find which episode a level belongs to
+ep_to_lvl = {
+    "Tide of Terror": ["Stealthy Approach", "Into the Machine", "High Class Heist", "Fire Down Below", "Cunning Disguise", "Gunboat Graveyard"],
+    "Sunset Snake Eyes": ["Rocky Start", "Boneyard Casino", "Straight to the Top", "Two to Tango", "Back Alley Heist"],
+    "Vicious Voodoo": ["Dread Swamp Path", "Lair of the Beast", "Grave Undertaking", "Descent into Danger"],
+    "Fire in the Sky": ["Perilous Ascent", "Flaming Temple of Flame", "Unseen Foe", "Duel by the Dragon"]
+}

--- a/worlds/sly1/Locations.py
+++ b/worlds/sly1/Locations.py
@@ -65,7 +65,7 @@ def generate_key_caches(world: "Sly1World", count: int) -> None:
         per_level_counts[name] += 1
         cache_num = per_level_counts[name]
         key_index = KEY_LOCATION_NAMES.index(name)
-        cache_name = f"{name} Cache #{cache_num}"
+        cache_name = f"{name}: Key Cache #{cache_num}"
         cache_code = KEY_CACHE_BASE + (key_index * 10) + (cache_num - 1)
         location = Sly1Location(world.player, cache_name, cache_code, reg)
         reg.locations.append(location)
@@ -80,16 +80,16 @@ def get_location_names() -> Dict[str, int]:
     for name, data in bottle_amounts.items():
         for bottle_number in range(1, data.bottle_amount + 1):
             bottle_code = data.ap_code + (bottle_number - 1)
-            bottle_location_name = f"{name} Bottle #{bottle_number}"
+            bottle_location_name = f"{name}: Bottle #{bottle_number}"
             all_possible_bottle_locations[bottle_location_name] = bottle_code
 
     # Add all the normal key minigame locations and all the cache options
     all_possible_minigame_locations = {}
     for name, data in minigame_locations.items():
-        base_name = name.removesuffix(" Key")
+        base_name = name.removesuffix(": Key")
         for cache_number in range(1, 11):
             cache_code = data.ap_code + cache_number
-            cache_location_name = f"{base_name} Cache #{cache_number}"
+            cache_location_name = f"{base_name}: Minigame Cache #{cache_number}"
             all_possible_minigame_locations[cache_location_name] = cache_code
 
     key_caches = {
@@ -136,7 +136,7 @@ def generate_bottle_locations(world: "Sly1World", bundle_size: int) -> Dict[str,
                 bottle_number = data.bottle_amount
             bottle_code = data.ap_code + (bottle_number - 1)
             # Delete every bottle so we can add only the ones that are valid
-            bottle_name = f"{name} Bottle #{bottle_number}"
+            bottle_name = f"{name}: Bottle #{bottle_number}"
             if bottle_name in location_table:
                 del location_table[bottle_name]
 
@@ -149,12 +149,12 @@ def generate_minigame_locations(world: "Sly1World", cache_size: int) -> Dict[str
             continue
 
         reg = world.multiworld.get_region(data.region, world.player)
-        base_name = name.removesuffix(" Key")
+        base_name = name.removesuffix(": Key")
 
         # Add cache locations if cache_size > 0
         if cache_size > 0:
             for cache_number in range(1, cache_size + 1):
-                cache_name = f"{base_name} Cache #{cache_number}"
+                cache_name = f"{base_name}: Minigame Cache #{cache_number}"
                 cache_code = data.ap_code + cache_number
                 cache_location = Sly1Location(world.player, cache_name, cache_code, reg)
                 reg.locations.append(cache_location)
@@ -164,31 +164,31 @@ sly_locations = {
 
     ## Key Locations - Finishing the level
     # Tide of Terror
-    "Stealthy Approach Key": LocData(10020101, "Stealthy Approach", key_type=EpisodeType.TOT),
-    "Into the Machine Key": LocData(10020102, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
-    "High Class Heist Key": LocData(10020103, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
-    "Fire Down Below Key": LocData(10020104, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
-    "Cunning Disguise Key": LocData(10020105, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
-    "Gunboat Graveyard Key": LocData(10020106, "Prowling the Grounds - Second Gate", key_type=EpisodeType.TOT, key_requirement = 3),
+    "Stealthy Approach: Key": LocData(10020101, "Stealthy Approach", key_type=EpisodeType.TOT),
+    "Into the Machine: Key": LocData(10020102, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
+    "High Class Heist: Key": LocData(10020103, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
+    "Fire Down Below: Key": LocData(10020104, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
+    "Cunning Disguise: Key": LocData(10020105, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
+    "Gunboat Graveyard: Key": LocData(10020106, "Prowling the Grounds - Second Gate", key_type=EpisodeType.TOT, key_requirement = 3),
 
     # Sunset Snake Eyes
-    "Rocky Start Key": LocData(10020108, "Rocky Start", key_type=EpisodeType.SSE),
-    "Boneyard Casino Key": LocData(10020111, "Muggshot's Turf", key_type=EpisodeType.SSE, key_requirement = 1),
-    "Straight to the Top Key": LocData(10020112, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
-    "Two to Tango Key": LocData(10020113, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
-    "Back Alley Heist Key": LocData(10020114, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
+    "Rocky Start: Key": LocData(10020108, "Rocky Start", key_type=EpisodeType.SSE),
+    "Boneyard Casino: Key": LocData(10020111, "Muggshot's Turf", key_type=EpisodeType.SSE, key_requirement = 1),
+    "Straight to the Top: Key": LocData(10020112, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
+    "Two to Tango: Key": LocData(10020113, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
+    "Back Alley Heist: Key": LocData(10020114, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
 
     # Vicious Voodoo
-    "Dread Swamp Path Key": LocData(10020115, "Dread Swamp Path", key_type=EpisodeType.VV),
-    "Lair of the Beast Key": LocData(10020116, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1),
-    "Grave Undertaking Key": LocData(10020117, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1),
-    "Descent into Danger Key": LocData(10020119, "Swamp's Dark Center - Second Gate", key_type=EpisodeType.VV, key_requirement = 3),
+    "Dread Swamp Path: Key": LocData(10020115, "Dread Swamp Path", key_type=EpisodeType.VV),
+    "Lair of the Beast: Key": LocData(10020116, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1),
+    "Grave Undertaking: Key": LocData(10020117, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1),
+    "Descent into Danger: Key": LocData(10020119, "Swamp's Dark Center - Second Gate", key_type=EpisodeType.VV, key_requirement = 3),
 
     # Fire in the Sky
-    "Perilous Ascent Key": LocData(10020122, "Perilous Ascent", key_type=EpisodeType.FITS),
-    "Unseen Foe Key": LocData(10020123, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1),
-    "Flaming Temple of Flame Key": LocData(10020124, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1),
-    "Duel by the Dragon Key": LocData(10020128, "Inside the Stronghold - Second Gate", key_type=EpisodeType.FITS, key_requirement = 3),
+    "Perilous Ascent: Key": LocData(10020122, "Perilous Ascent", key_type=EpisodeType.FITS),
+    "Unseen Foe: Key": LocData(10020123, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1),
+    "Flaming Temple of Flame: Key": LocData(10020124, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1),
+    "Duel by the Dragon: Key": LocData(10020128, "Inside the Stronghold - Second Gate", key_type=EpisodeType.FITS, key_requirement = 3),
 
     ## Boss Victories
     "Eye of the Storm": LocData(10020229, "Eye of the Storm", key_type=EpisodeType.TOT, key_requirement = 7),
@@ -202,73 +202,73 @@ KEY_LOCATION_NAMES = [name for name in sly_locations if name.endswith(" Key")]
 hourglass_locations = {
     ## Hourglass Locations - Speedrunning the level
     # Tide of Terror
-    "Stealthy Approach Hourglass": LocData(10020301, "Stealthy Approach", key_type=EpisodeType.TOT, key_requirement = 1),
-    "Into the Machine Hourglass": LocData(10020302, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
-    "High Class Heist Hourglass": LocData(10020303, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
-    "Fire Down Below Hourglass": LocData(10020304, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
-    "Cunning Disguise Hourglass": LocData(10020305, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
-    "Gunboat Graveyard Hourglass": LocData(10020306, "Prowling the Grounds - Second Gate", key_type=EpisodeType.TOT, key_requirement = 3),
+    "Stealthy Approach: Hourglass": LocData(10020301, "Stealthy Approach", key_type=EpisodeType.TOT, key_requirement = 1),
+    "Into the Machine: Hourglass": LocData(10020302, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
+    "High Class Heist: Hourglass": LocData(10020303, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
+    "Fire Down Below: Hourglass": LocData(10020304, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
+    "Cunning Disguise: Hourglass": LocData(10020305, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
+    "Gunboat Graveyard: Hourglass": LocData(10020306, "Prowling the Grounds - Second Gate", key_type=EpisodeType.TOT, key_requirement = 3),
 
     # Sunset Snake Eyes
-    "Rocky Start Hourglass": LocData(10020308, "Rocky Start", key_type=EpisodeType.SSE, key_requirement = 1),
-    "Boneyard Casino Hourglass": LocData(10020311, "Muggshot's Turf", key_type=EpisodeType.SSE, key_requirement = 1),
-    "Straight to the Top Hourglass": LocData(10020312, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
-    "Two to Tango Hourglass": LocData(10020313, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
-    "Back Alley Heist Hourglass": LocData(10020314, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
+    "Rocky Start: Hourglass": LocData(10020308, "Rocky Start", key_type=EpisodeType.SSE, key_requirement = 1),
+    "Boneyard Casino: Hourglass": LocData(10020311, "Muggshot's Turf", key_type=EpisodeType.SSE, key_requirement = 1),
+    "Straight to the Top: Hourglass": LocData(10020312, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
+    "Two to Tango: Hourglass": LocData(10020313, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
+    "Back Alley Heist: Hourglass": LocData(10020314, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
 
     # Vicious Voodoo
-    "Dread Swamp Path Hourglass": LocData(10020315, "Dread Swamp Path", key_type=EpisodeType.VV, key_requirement = 1),
-    "Lair of the Beast Hourglass": LocData(10020316, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1),
-    "Grave Undertaking Hourglass": LocData(10020317, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1),
-    "Descent into Danger Hourglass": LocData(10020319, "Swamp's Dark Center - Second Gate", key_type=EpisodeType.VV, key_requirement = 3),
+    "Dread Swamp Path: Hourglass": LocData(10020315, "Dread Swamp Path", key_type=EpisodeType.VV, key_requirement = 1),
+    "Lair of the Beast: Hourglass": LocData(10020316, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1),
+    "Grave Undertaking: Hourglass": LocData(10020317, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1),
+    "Descent into Danger: Hourglass": LocData(10020319, "Swamp's Dark Center - Second Gate", key_type=EpisodeType.VV, key_requirement = 3),
 
     # Fire in the Sky
-    "Perilous Ascent Hourglass": LocData(10020322, "Perilous Ascent", key_type=EpisodeType.FITS, key_requirement = 1),
-    "Unseen Foe Hourglass": LocData(10020323, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1),
-    "Flaming Temple of Flame Hourglass": LocData(10020324, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1),
-    "Duel by the Dragon Hourglass": LocData(10020328, "Inside the Stronghold - Second Gate", key_type=EpisodeType.FITS, key_requirement = 3),
+    "Perilous Ascent: Hourglass": LocData(10020322, "Perilous Ascent", key_type=EpisodeType.FITS, key_requirement = 1),
+    "Unseen Foe: Hourglass": LocData(10020323, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1),
+    "Flaming Temple of Flame: Hourglass": LocData(10020324, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1),
+    "Duel by the Dragon: Hourglass": LocData(10020328, "Inside the Stronghold - Second Gate", key_type=EpisodeType.FITS, key_requirement = 3),
 }
 
 vault_locations = {
     ## Vault Locations - Collecting all bottles in level
     # Tide of Terror
-    "Stealthy Approach Vault": LocData(10020201, "Stealthy Approach", key_type=EpisodeType.TOT),
-    "Into the Machine Vault": LocData(10020202, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
-    "High Class Heist Vault": LocData(10020203, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
-    "Fire Down Below Vault": LocData(10020204, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
-    "Cunning Disguise Vault": LocData(10020205, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
-    "Gunboat Graveyard Vault": LocData(10020206, "Prowling the Grounds - Second Gate", key_type=EpisodeType.TOT, key_requirement = 3),
+    "Stealthy Approach: Vault": LocData(10020201, "Stealthy Approach", key_type=EpisodeType.TOT),
+    "Into the Machine: Vault": LocData(10020202, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
+    "High Class Heist: Vault": LocData(10020203, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
+    "Fire Down Below: Vault": LocData(10020204, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
+    "Cunning Disguise: Vault": LocData(10020205, "Prowling the Grounds", key_type=EpisodeType.TOT, key_requirement = 1),
+    "Gunboat Graveyard: Vault": LocData(10020206, "Prowling the Grounds - Second Gate", key_type=EpisodeType.TOT, key_requirement = 3),
 
     # Sunset Snake Eyes
-    "Rocky Start Vault": LocData(10020208, "Rocky Start", key_type=EpisodeType.SSE),
-    "Boneyard Casino Vault": LocData(10020211, "Muggshot's Turf", key_type=EpisodeType.SSE, key_requirement = 1),
-    "Straight to the Top Vault": LocData(10020212, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
-    "Two to Tango Vault": LocData(10020213, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
-    "Back Alley Heist Vault": LocData(10020214, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
+    "Rocky Start: Vault": LocData(10020208, "Rocky Start", key_type=EpisodeType.SSE),
+    "Boneyard Casino: Vault": LocData(10020211, "Muggshot's Turf", key_type=EpisodeType.SSE, key_requirement = 1),
+    "Straight to the Top: Vault": LocData(10020212, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
+    "Two to Tango: Vault": LocData(10020213, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
+    "Back Alley Heist: Vault": LocData(10020214, "Muggshot's Turf - Second Gate", key_type=EpisodeType.SSE, key_requirement = 3),
 
     # Vicious Voodoo
-    "Dread Swamp Path Vault": LocData(10020215, "Dread Swamp Path", key_type=EpisodeType.VV),
-    "Lair of the Beast Vault": LocData(10020216, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1),
-    "Grave Undertaking Vault": LocData(10020217, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1),
-    "Descent into Danger Vault": LocData(10020219, "Swamp's Dark Center - Second Gate", key_type=EpisodeType.VV, key_requirement = 3),
+    "Dread Swamp Path: Vault": LocData(10020215, "Dread Swamp Path", key_type=EpisodeType.VV),
+    "Lair of the Beast: Vault": LocData(10020216, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1),
+    "Grave Undertaking: Vault": LocData(10020217, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1),
+    "Descent into Danger: Vault": LocData(10020219, "Swamp's Dark Center - Second Gate", key_type=EpisodeType.VV, key_requirement = 3),
 
     # Fire in the Sky
-    "Perilous Ascent Vault": LocData(10020222, "Perilous Ascent", key_type=EpisodeType.FITS),
-    "Unseen Foe Vault": LocData(10020223, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1),
-    "Flaming Temple of Flame Vault": LocData(10020224, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1),
-    "Duel by the Dragon Vault": LocData(10020228, "Inside the Stronghold - Second Gate", key_type=EpisodeType.FITS, key_requirement = 3)
+    "Perilous Ascent: Vault": LocData(10020222, "Perilous Ascent", key_type=EpisodeType.FITS),
+    "Unseen Foe: Vault": LocData(10020223, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1),
+    "Flaming Temple of Flame: Vault": LocData(10020224, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1),
+    "Duel by the Dragon: Vault": LocData(10020228, "Inside the Stronghold - Second Gate", key_type=EpisodeType.FITS, key_requirement = 3)
 }
 
 minigame_locations = {
-    "Treasure in the Depths Key": LocData(10021000, "Prowling the Grounds - Second Gate", key_type=EpisodeType.TOT, key_requirement = 3, level_type = "Crabs"),
-    "At the Dog Track Key": LocData(10021100, "Muggshot's Turf", key_type=EpisodeType.SSE, key_requirement = 1, level_type = "Races"),
-    "Murray's Big Gamble Key": LocData(10021200, "Muggshot's Turf", key_type=EpisodeType.SSE, key_requirement = 1, level_type = "Turrets"),
-    "Piranha Lake Key": LocData(10021300, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1, level_type = "Swamp Skiff"),
-    "Ghastly Voyage Key": LocData(10021400, "Swamp's Dark Center - Second Gate", key_type=EpisodeType.VV, key_requirement = 3, level_type = "Hover Blasters"),
-    "Down Home Cooking Key": LocData(10021500, "Swamp's Dark Center - Second Gate", key_type=EpisodeType.VV, key_requirement = 3, level_type = "Chicken Killing"),
-    "King of the Hill Key": LocData(10021600, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1, level_type = "Turrets"),
-    "Rapid Fire Assault Key": LocData(10021700, "Inside the Stronghold - Second Gate", key_type=EpisodeType.FITS, key_requirement = 3, level_type = "Hover Blasters"),
-    "Desperate Race Key": LocData(10021800, "Inside the Stronghold - Second Gate", key_type=EpisodeType.FITS, key_requirement = 3, level_type = "Races")
+    "Treasure in the Depths: Key": LocData(10021000, "Prowling the Grounds - Second Gate", key_type=EpisodeType.TOT, key_requirement = 3, level_type = "Crabs"),
+    "At the Dog Track: Key": LocData(10021100, "Muggshot's Turf", key_type=EpisodeType.SSE, key_requirement = 1, level_type = "Races"),
+    "Murray's Big Gamble: Key": LocData(10021200, "Muggshot's Turf", key_type=EpisodeType.SSE, key_requirement = 1, level_type = "Turrets"),
+    "Piranha Lake: Key": LocData(10021300, "Swamp's Dark Center", key_type=EpisodeType.VV, key_requirement = 1, level_type = "Swamp Skiff"),
+    "Ghastly Voyage: Key": LocData(10021400, "Swamp's Dark Center - Second Gate", key_type=EpisodeType.VV, key_requirement = 3, level_type = "Hover Blasters"),
+    "Down Home Cooking: Key": LocData(10021500, "Swamp's Dark Center - Second Gate", key_type=EpisodeType.VV, key_requirement = 3, level_type = "Chicken Killing"),
+    "King of the Hill: Key": LocData(10021600, "Inside the Stronghold", key_type=EpisodeType.FITS, key_requirement = 1, level_type = "Turrets"),
+    "Rapid Fire Assault: Key": LocData(10021700, "Inside the Stronghold - Second Gate", key_type=EpisodeType.FITS, key_requirement = 3, level_type = "Hover Blasters"),
+    "Desperate Race: Key": LocData(10021800, "Inside the Stronghold - Second Gate", key_type=EpisodeType.FITS, key_requirement = 3, level_type = "Races")
 }
 
 event_locations = {
@@ -303,6 +303,18 @@ bottle_amounts = {
     "Unseen Foe":           LevelData(10020900, "Unseen Foe", 30),
     "Duel by the Dragon":       LevelData(10020955, "Duel by the Dragon", 40)
 }
+
+# these are all for use in location group setup to simplify things
+sly_minigames = ["Treasure in the Depths", "Ghastly Voyage", "Rapid Fire Assault", "Piranha Lake", "Down Home Cooking"]
+races = ["At the Dog Track", "Desperate Race"]
+murray_dangers = ["Murray's Big Gamble", "King of the Hill"]
+all_minigames = sly_minigames + races + murray_dangers + ["Down Home Cooking"]
+lvl_lookup = {"Race": races, "Murray Danger": murray_dangers, "Sly Minigame": sly_minigames}
+
+loc_to_ep = dict.fromkeys(["Stealthy Approach", "Into the Machine", "High Class Heist", "Fire Down Below", "Cunning Disguise", "Gunboat Graveyard", "Treasure in the Depths"], "Tide of Terror")
+loc_to_ep.update(dict.fromkeys(["Rocky Start", "Boneyard Casino", "Straight to the Top", "Two to Tango", "Back Alley Heist", "Murray's Big Gamble", "At the Dog Track"], "Sunset Snake Eyes"))
+loc_to_ep.update(dict.fromkeys(["Dread Swamp Path", "Lair of the Beast", "Grave Undertaking", "Descent into Danger", "Ghastly Voyage", "Down Home Cooking", "Piranha Lake"], "Vicious Voodoo"))
+loc_to_ep.update(dict.fromkeys(["Perilous Ascent", "Flaming Temple of Flame", "Unseen Foe", "Duel by the Dragon", "Desperate Race", "King of the Hill", "Rapid Fire Assault"], "Fire in the Sky"))
 
 location_table = {
     **sly_locations,

--- a/worlds/sly1/Options.py
+++ b/worlds/sly1/Options.py
@@ -57,7 +57,9 @@ class RequiredPages(Range):
 
 class StartingEpisode(Choice):
     """
-    Determines which episode you will have the intro for at the beginning of the game.
+    Determines which episode you will start in. You will be able to do the initial level for it, but
+    will only be able to continue if you receive a key for that episode (or unlock a different episode)
+    from a location within it. Avoid Early BK is suggested if you want to avoid early stuck points.
     """
     display_name = "Starting Episode"
     option_tide_of_terror = 1
@@ -93,7 +95,7 @@ class ExcludeMinigames(OptionSet):
     Crabs: Treasure in the Depths
     Races: At the Dog Track, A Desperate Race
     Turrets: Murray's Big Gamble, The King of the Hill
-    Hover Blasters: A Ghastly Voyage, Rapid Fire Assualt
+    Hover Blasters: A Ghastly Voyage, Rapid Fire Assault
     Chicken Killing: Down Home Cooking
     Swamp Skiff: Piranha Lake
     """
@@ -109,8 +111,9 @@ class ExcludeMinigames(OptionSet):
 
 class MinigameCaches(Range):
     """
-    Determines how many checks minigames send when completed. Ignored if the minigame is excluded.
-    Allows a range from 0-10.
+    Determines how many additional "minigame cache" checks that minigame levels send when completed.
+    Minigame levels will still have a key location even if this is set to 0.
+    This is ignored for any minigame levels excluded above. Allows a range from 0-10.
     """
     display_name = "Minigame Caches"
     range_start = 0
@@ -147,7 +150,7 @@ class CutsceneSkip(Toggle):
 
 class TrapChance(Range):
     """
-    Determines the chance for any junk item to become a trap.
+    Determines the chance for a filler item to become a trap.
     Set it to 0 for no traps.
     """
     display_name = "Include Traps"
@@ -195,6 +198,27 @@ class BallTrapWeight(Range):
     range_end = 100
     default = 25
 
+class EnableTricks(OptionSet):
+    """
+    This option allows you to enable alternative forms of logic to access parts of the game via tricks.
+    Intended for use by people who know speedrun tricks already, but if you would like to learn, watch an
+    Any% run of the game for reference on how to do the below tricks.
+
+    Tide of Terror supports tot_second_half_early and tot_raleigh_early.
+    Sunset Snake Eyes supports sse_second_half_early and sse_muggshot_early.
+    Vicious Voodoo only supports vv_second_half early as Mz. Ruby does not have known methods of early access.
+    Fire in the Sky supports fits_second_half_early and fits_panda_early.
+    Additionally, an 8th trick unseen_foe_invis_skip is supported which puts all Unseen Foe locations into logic
+    without requiring any progressive invisibility items.
+
+    Including any of the tricks below will potentially require you to do those tricks to progress, depending
+    on the randomization.
+    """
+    display_name = "Enable Tricks"
+    default = []
+    valid_keys = ["tot_second_half_early", "tot_raleigh_early", "sse_second_half_early", "sse_muggshot_early",
+                  "vv_second_half_early", "fits_second_half_early", "fits_panda_early", "unseen_foe_invis_skip"]
+
 @dataclass
 class Sly1Options(PerGameCommonOptions):
     UnlockClockwerk:                UnlockClockwerk
@@ -210,6 +234,7 @@ class Sly1Options(PerGameCommonOptions):
     MinigameCaches:                 MinigameCaches
     LocationCluesanityBundleSize:   LocationCluesanityBundleSize
     ItemCluesanityBundleSize:       ItemCluesanityBundleSize
+    EnableTricks:                   EnableTricks
     CutsceneSkip:                   CutsceneSkip
     TrapChance:                     TrapChance
     IcePhysicsTrapWeight:           IcePhysicsTrapWeight
@@ -222,7 +247,7 @@ sly1_option_groups: Dict[str, List[Any]] = {
                          RequiredBosses, MaxPages,
                          RequiredPages, StartingEpisode,
                          IncludeHourglasses, HourglassesRequireRoll,
-                         CutsceneSkip],
+                         EnableTricks, CutsceneSkip],
     "Minigame Options": [ExcludeMinigames, MinigameCaches],
     "Cluesanity Options": [LocationCluesanityBundleSize, ItemCluesanityBundleSize],
     "Trap Options": [TrapChance, IcePhysicsTrapWeight,

--- a/worlds/sly1/Rules.py
+++ b/worlds/sly1/Rules.py
@@ -1,5 +1,5 @@
 from worlds.generic.Rules import add_rule, set_rule
-from worlds.sly1.Types import episode_type_to_shortened_name
+from worlds.sly1.Types import episode_type_to_unlock
 from worlds.sly1.Locations import hourglass_locations, vault_locations, did_include_hourglasses, get_bundle_amount_for_level
 from typing import TYPE_CHECKING
 
@@ -13,56 +13,65 @@ def set_rules(world: "Sly1World"):
 
     # Episode Access
     add_rule(world.multiworld.get_entrance("Hideout -> Stealthy Approach", player),
-             lambda state: state.has("Tide of Terror", player))
+             lambda state: state.has("Tide of Terror: Episode Unlock", player))
     add_rule(world.multiworld.get_entrance("Hideout -> Rocky Start", player),
-             lambda state: state.has("Sunset Snake Eyes", player))
+             lambda state: state.has("Sunset Snake Eyes: Episode Unlock", player))
     add_rule(world.multiworld.get_entrance("Hideout -> Dread Swamp Path", player),
-             lambda state: state.has("Vicious Voodoo", player))
+             lambda state: state.has("Vicious Voodoo: Episode Unlock", player))
     add_rule(world.multiworld.get_entrance("Hideout -> Perilous Ascent", player),
-             lambda state: state.has("Fire in the Sky", player))
+             lambda state: state.has("Fire in the Sky: Episode Unlock", player))
     
     # Main Hub Access
     add_rule(world.multiworld.get_entrance("Hideout -> Prowling the Grounds", player),
-             lambda state: state.has("ToT Key", player)
-             and state.has("Tide of Terror", player))
+             lambda state: state.has("Tide of Terror: Key", player)
+             and state.has("Tide of Terror: Episode Unlock", player))
     add_rule(world.multiworld.get_entrance("Hideout -> Muggshot's Turf", player),
-             lambda state: state.has("SSE Key", player)
-             and state.has("Sunset Snake Eyes", player))
+             lambda state: state.has("Sunset Snake Eyes: Key", player)
+             and state.has("Sunset Snake Eyes: Episode Unlock", player))
     add_rule(world.multiworld.get_entrance("Hideout -> Swamp's Dark Center", player),
-             lambda state: state.has("VV Key", player)
-             and state.has("Vicious Voodoo", player))
+             lambda state: state.has("Vicious Voodoo: Key", player)
+             and state.has("Vicious Voodoo: Episode Unlock", player))
     add_rule(world.multiworld.get_entrance("Hideout -> Inside the Stronghold", player),
-             lambda state: state.has("FitS Key", player)
-             and state.has("Fire in the Sky", player))
+             lambda state: state.has("Fire in the Sky: Key", player)
+             and state.has("Fire in the Sky: Episode Unlock", player))
     
     add_rule(world.multiworld.get_entrance("Stealthy Approach -> Prowling the Grounds", player),
-             lambda state: state.has("ToT Key", player))
+             lambda state: state.has("Tide of Terror: Key", player))
     add_rule(world.multiworld.get_entrance("Rocky Start -> Muggshot's Turf", player),
-             lambda state: state.has("SSE Key", player))
+             lambda state: state.has("Sunset Snake Eyes: Key", player))
     add_rule(world.multiworld.get_entrance("Dread Swamp Path -> Swamp's Dark Center", player),
-             lambda state: state.has("VV Key", player))
+             lambda state: state.has("Vicious Voodoo: Key", player))
     add_rule(world.multiworld.get_entrance("Perilous Ascent -> Inside the Stronghold", player),
-             lambda state: state.has("FitS Key", player))
+             lambda state: state.has("Fire in the Sky: Key", player))
     
     # Hub 2 Access
+    tricks: list = options.EnableTricks.value
+    tot_second_half = True if "tot_second_half_early" in tricks else False
+    sse_second_half = True if "sse_second_half_early" in tricks else False
+    vv_second_half = True if "vv_second_half_early" in tricks else False
+    fits_second_half = True if "fits_second_half_early" in tricks else False
     add_rule(world.multiworld.get_entrance("Prowling the Grounds -> Prowling the Grounds - Second Gate", player),
-             lambda state: state.has("ToT Key", player, 3))
+             lambda state: state.has("Tide of Terror: Key", player, 3) or tot_second_half)
     add_rule(world.multiworld.get_entrance("Muggshot's Turf -> Muggshot's Turf - Second Gate", player),
-             lambda state: state.has("SSE Key", player, 3))
+             lambda state: state.has("Sunset Snake Eyes: Key", player, 3) or sse_second_half)
     add_rule(world.multiworld.get_entrance("Swamp's Dark Center -> Swamp's Dark Center - Second Gate", player),
-             lambda state: state.has("VV Key", player, 3))
+             lambda state: state.has("Vicious Voodoo: Key", player, 3) or vv_second_half)
     add_rule(world.multiworld.get_entrance("Inside the Stronghold -> Inside the Stronghold - Second Gate", player),
-             lambda state: state.has("FitS Key", player, 3))
+             lambda state: state.has("Fire in the Sky: Key", player, 3) or fits_second_half)
     
     # Boss Access
+    raleigh_early = True if "tot_raleigh_early" in tricks else False
+    muggshot_early = True if "sse_muggshot_early" in tricks else False
+    # no skip into Mz. Ruby early yet...some day...
+    panda_early = True if "fits_panda_early" in tricks else False
     add_rule(world.multiworld.get_entrance("Prowling the Grounds - Second Gate -> Eye of the Storm", player),
-             lambda state: state.has("ToT Key", player, 7))
+             lambda state: state.has("Tide of Terror: Key", player, 7) or raleigh_early)
     add_rule(world.multiworld.get_entrance("Muggshot's Turf - Second Gate -> Last Call", player),
-             lambda state: state.has("SSE Key", player, 7))
+             lambda state: state.has("Sunset Snake Eyes: Key", player, 7) or muggshot_early)
     add_rule(world.multiworld.get_entrance("Swamp's Dark Center - Second Gate -> Deadly Dance", player),
-             lambda state: state.has("VV Key", player, 7))
+             lambda state: state.has("Vicious Voodoo: Key", player, 7))
     add_rule(world.multiworld.get_entrance("Inside the Stronghold - Second Gate -> Flame Fu!", player),
-             lambda state: state.has("FitS Key", player, 7))
+             lambda state: state.has("Fire in the Sky: Key", player, 7) or panda_early)
     
     # Cold Heart of Hate Access
     if options.UnlockClockwerk.value == 1:
@@ -75,9 +84,9 @@ def set_rules(world: "Sly1World"):
     # Cluesanity rules
     if options.ItemCluesanityBundleSize.value > 0:
         for name, data in vault_locations.items():
-            level_name = name.rsplit(' ', 1)[0]
+            level_name = name.split(':')[0]
             bundle_amount = get_bundle_amount_for_level(level_name, world.options.ItemCluesanityBundleSize.value)
-            bottle_name = f'{level_name} Bottle(s)'
+            bottle_name = f'{level_name}: Bottle(s)'
             
             add_rule(world.multiworld.get_location(name, player),
                      lambda state, bn=bottle_name, ba=bundle_amount: state.has(bn, player, ba))
@@ -86,30 +95,32 @@ def set_rules(world: "Sly1World"):
     if did_include_hourglasses(world):
         for key, data in hourglass_locations.items():
             loc = world.multiworld.get_location(key, player)
-            add_rule(loc, lambda state, key_name = f"{episode_type_to_shortened_name[data.key_type]} Key", key_req=data.key_requirement:
+            ep_name = episode_type_to_unlock[data.key_type].replace(": Episode Unlock", "")
+            add_rule(loc, lambda state, key_name = f"{ep_name}: Key", key_req=data.key_requirement:
                 state.has(key_name, player, key_req))
 
             if options.HourglassesRequireRoll:
                 add_rule(loc, lambda state, roll = "Progressive Roll": state.has(roll, player, 1))
 
             if world.options.ItemCluesanityBundleSize.value > 0:
-                level_name = key.rsplit(' ', 1)[0]
+                level_name = key.split(':')[0]
                 bundle_amount = get_bundle_amount_for_level(level_name, world.options.ItemCluesanityBundleSize.value)
-                bottle_name = f'{level_name} Bottle(s)'
+                bottle_name = f'{level_name}: Bottle(s)'
 
                 add_rule(world.multiworld.get_location(key, player),
                         lambda state, bn=bottle_name, ba=bundle_amount: state.has(bn, player, ba))
 
-        add_rule(world.multiworld.get_location("Unseen Foe Hourglass", player),
+        add_rule(world.multiworld.get_location("Unseen Foe: Hourglass", player),
              lambda state: state.has("Progressive Invisibility", player, 1))
 
     # Extra rules for Unseen Foe
-    add_rule(world.multiworld.get_location("Unseen Foe Key", player),
-             lambda state: state.has("Progressive Invisibility", player, 1))
-    add_rule(world.multiworld.get_location("Unseen Foe Vault", player),
-             lambda state: state.has("Progressive Invisibility", player, 1))
+    invis_skip = True if "unseen_foe_invis_skip" in world.options.EnableTricks.value else False
+    add_rule(world.multiworld.get_location("Unseen Foe: Key", player),
+             lambda state: state.has("Progressive Invisibility", player, 1) or invis_skip)
+    add_rule(world.multiworld.get_location("Unseen Foe: Vault", player),
+             lambda state: state.has("Progressive Invisibility", player, 1) or invis_skip)
     for location in world.multiworld.get_locations(player):
         if "Unseen Foe" in location.name and "Bottle" in location.name:
-            add_rule(location, lambda state: state.has("Progressive Invisibility", player, 1))
+            add_rule(location, lambda state: state.has("Progressive Invisibility", player, 1) or invis_skip)
 
     world.multiworld.completion_condition[player] = lambda state: state.has("Victory", player)

--- a/worlds/sly1/Types.py
+++ b/worlds/sly1/Types.py
@@ -37,11 +37,11 @@ class LevelData(NamedTuple):
     region: Optional[str]
     bottle_amount: Optional[int]
 
-episode_type_to_name = {
-    EpisodeType.TOT:      "Tide of Terror",
-    EpisodeType.SSE:      "Sunset Snake Eyes",
-    EpisodeType.VV:       "Vicious Voodoo",
-    EpisodeType.FITS:     "Fire in the Sky",
+episode_type_to_unlock = {
+    EpisodeType.TOT:      "Tide of Terror: Episode Unlock",
+    EpisodeType.SSE:      "Sunset Snake Eyes: Episode Unlock",
+    EpisodeType.VV:       "Vicious Voodoo: Episode Unlock",
+    EpisodeType.FITS:     "Fire in the Sky: Episode Unlock",
     EpisodeType.CHOH:     "Cold Heart of Hate",
     EpisodeType.ALL:      "All"
 }

--- a/worlds/sly1/__init__.py
+++ b/worlds/sly1/__init__.py
@@ -1,15 +1,17 @@
 import random
 import logging
+from collections import defaultdict
 from typing import Dict, Union, ClassVar, Any, Mapping
 from BaseClasses import MultiWorld, Item, ItemClassification, Tutorial
 from worlds.AutoWorld import World, CollectionState, WebWorld
-from worlds.sly1.Items import item_table, create_itempool, create_item, event_item_pairs, sly_episodes
+from worlds.sly1.Items import item_table, create_itempool, create_item, event_item_pairs, sly_episodes, sly_items, bottles, junk_items, ep_to_lvl
 from worlds.sly1.Locations import (get_location_names, get_total_locations,
                                    did_avoid_early_bk, generate_bottle_locations,
-                                   generate_minigame_locations, generate_key_caches)
+                                   generate_minigame_locations, generate_key_caches,
+                                   loc_to_ep, all_minigames, lvl_lookup)
 from worlds.sly1.Options import Sly1Options
 from worlds.sly1.Regions import create_regions
-from worlds.sly1.Types import Sly1Item, EpisodeType, episode_type_to_name, episode_type_to_shortened_name
+from worlds.sly1.Types import Sly1Item, EpisodeType, episode_type_to_unlock
 from worlds.sly1.Rules import set_rules
 from worlds.LauncherComponents import (
     Component,
@@ -29,6 +31,76 @@ def run_client():
 components.append(
     Component("Sly 1 Client", func=run_client, component_type=Type.CLIENT)
 )
+
+def setup_item_groups(items) -> dict[str, set]:
+    item_groups = defaultdict(set)
+    for item in items:
+        if "Progressive" in item:
+            item_groups["Moves (Progressive)"].add(item)
+            item_groups["Moves (All)"].add(item)
+        if item in ["Coin Magnet", "Mine", "Fast", "Decoy", "Hacking"]:  # couldn't think of a good way to rename these for dynamic logic
+            item_groups["Moves (Non-Progressive)"].add(item)
+            item_groups["Moves (All)"].add(item)
+        if item in junk_items and "Trap" not in item:
+            item_groups["All Filler"].add(item)
+        if item in junk_items and "Trap" in item:
+            item_groups["All Traps"].add(item)
+
+        if item.find(":") == -1:  # all remaining items we care about will have a : in them
+            continue
+        ep_or_lvl, item_type = item.split(":")  # unknown at this stage if this is an episode or level item
+
+        if ep_or_lvl in ep_to_lvl.keys():  # if true, this is an episode-based item
+            for group_type in ["Blueprint", "Key", "Episode Unlock"]:
+                if group_type in item_type:
+                    item_groups[f"{ep_or_lvl} (All)"].add(item)
+                    item_groups[f"All {group_type}s"].add(item)
+                    break  # small optimization to stop once found
+        else:  # if else, this is a bottle item (all level-based items are bottle items) and we must find which episode it belongs to
+            for episode in ep_to_lvl:  # could make this a direct lookup if another dict was made for level -> ep, but I didn't find that justified
+                if ep_or_lvl in ep_to_lvl[episode]:  # found the level in an episode's list
+                    item_groups[f"{episode} Bottles"].add(item)
+                    item_groups[f"{episode} (All)"].add(item)
+                    item_groups[f"All Bottles"].add(item)
+                    break  # small optimization to stop once found
+    return item_groups
+
+def setup_location_groups(locations) -> dict[str, set]:
+    location_groups = defaultdict(set)
+    location_groups["All Bosses"] = {"Eye of the Storm", "Last Call", "Deadly Dance", "Flame Fu!"}  # rest of loop is simpler if this is hardcoded here
+
+    # this is SO much better and more efficient now, at the cost of reformatting almost all location names. Worth it 100% imo
+    for loc in locations:
+        if loc.find(":") == -1:  # paris files and boss-related locations intentionally do not have a : and aren't in any groups
+            continue
+
+        # all locations (minus the ones skipped above) have format of "Level: Location Type" e.g. Stealthy Approach: Key or Treasure in the Depths: Minigame Cache #3
+        level, loc_type = loc.split(":")
+        episode = loc_to_ep[level]
+
+        location_groups[f"{episode} (All)"].add(loc)  # everything in an episode
+
+        # generalizing per-level, per-episode, and full-game groups for bottles, keys, minigame caches, vaults, and hourglasses
+        # doing this cuts out a ton of redundancy in lines of code because most groups are similar
+        def helper(single, plural):  # singular and plural form of the group names. All because hourglasses pluralizes weirdly
+            if single in loc_type:  # every location gets checked for if it's a bottle, key, etc. so only continue if there's a match
+                if single in ["Bottle", "Minigame Cache"] or (single == "Key" and level not in all_minigames):  # only do per-level key groups for non-minigames
+                    location_groups[f"{level} {plural}"].add(loc)
+                location_groups[f"{episode} {plural}"].add(loc)
+                location_groups[f"All {plural}"].add(loc)
+
+        for single in ["Bottle", "Key", "Minigame Cache", "Vault", "Hourglass"]:
+            plural = "Hourglasses" if single == "Hourglass" else single + "s"  # hourglass is the only one that can't be pluralized with just adding an s. I hate English
+            helper(single, plural)
+
+        for lvl_string, lvl_list in lvl_lookup.items():
+            if level in lvl_list:
+                location_groups[f"All {lvl_string} Levels"].add(loc)
+
+        if level not in all_minigames:  # minigame levels don't have enough diversity in locations to justify {level} (All) groups
+            location_groups["All Platforming Levels"].add(loc)
+            location_groups[f"{level} (All)"].add(loc)
+    return location_groups
 
 class Sly1Web(WebWorld):
     theme = "ocean"
@@ -64,6 +136,10 @@ class Sly1World(World):
     web = Sly1Web()
     settings: ClassVar[Sly1Settings]
 
+    # set up item and location groups
+    item_name_groups = setup_item_groups(item_name_to_id)
+    location_name_groups = setup_location_groups(location_name_to_id)
+
     # this is how we tell the Universal Tracker we want to use re_gen_passthrough
     @staticmethod
     def interpret_slot_data(slot_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -93,6 +169,7 @@ class Sly1World(World):
                     self.options.StartingEpisode.value = slot_data["StartingEpisode"]
                     self.options.IncludeHourglasses.value = slot_data["IncludeHourglasses"]
                     self.options.HourglassesRequireRoll.value = slot_data["HourglassesRequireRoll"]
+                    self.options.EnableTricks.value = slot_data["EnableTricks"]
                     self.options.AvoidEarlyBK.value = slot_data["AvoidEarlyBK"]
                     self.options.ExcludeMinigames.value = slot_data["ExcludeMinigames"]
                     self.options.MinigameCaches.value = slot_data["MinigameCaches"]
@@ -107,22 +184,22 @@ class Sly1World(World):
             return
 
         starting_episode = EpisodeType(self.options.StartingEpisode)
-        starting_episode_long = episode_type_to_name[starting_episode]
-        starting_episode_short = episode_type_to_shortened_name[starting_episode]
+        starting_episode_unlock = episode_type_to_unlock[starting_episode]
+        starting_episode_name = starting_episode_unlock.replace(": Episode Unlock", "")
 
         # Starting Episode - please clean this up oml
-        if starting_episode_long == "All":
+        if starting_episode_name == "All":
             for episode in sly_episodes.keys():
                 self.multiworld.push_precollected(self.create_item(episode))
         else:
-            self.multiworld.push_precollected(self.create_item(starting_episode_long))
+            self.multiworld.push_precollected(self.create_item(starting_episode_unlock))
 
         # Avoid Early BK
         if did_avoid_early_bk(self):
-            if starting_episode_long == "All":
-                starting_episode_short = episode_type_to_shortened_name[EpisodeType(random.randrange(1, 4))]
-                self.random_episode = starting_episode_short
-            self.multiworld.push_precollected(self.create_item(f'{starting_episode_short} Key'))
+            if starting_episode_name == "All":
+                starting_episode_name = episode_type_to_unlock[EpisodeType(random.randint(1, 4))].replace(": Episode Unlock", "")
+                self.random_episode = starting_episode_name
+            self.multiworld.push_precollected(self.create_item(f'{starting_episode_name}: Key'))
 
     def create_regions(self):
         create_regions(self)
@@ -187,6 +264,7 @@ class Sly1World(World):
             "IncludeHourglasses",
             "HourglassesRequireRoll",
             "AvoidEarlyBK",
+            "EnableTricks",
             "LocationCluesanityBundleSize",
             "ItemCluesanityBundleSize",
             "CutsceneSkip",
@@ -210,6 +288,7 @@ class Sly1World(World):
             "IncludeHourglasses": self.options.IncludeHourglasses.value,
             "HourglassesRequireRoll": self.options.HourglassesRequireRoll.value,
             "AvoidEarlyBK": self.options.AvoidEarlyBK.value,
+            "EnableTricks": self.options.EnableTricks.value,
             "LocationCluesanityBundleSize": self.options.LocationCluesanityBundleSize.value,
             "ItemCluesanityBundleSize": self.options.ItemCluesanityBundleSize.value,
             "CutsceneSkip": self.options.CutsceneSkip.value,

--- a/worlds/sly1/archipelago.json
+++ b/worlds/sly1/archipelago.json
@@ -1,0 +1,4 @@
+{
+  "game": "Sly Cooper and the Thievius Raccoonus",
+  "world_version": "0.4.1"
+}

--- a/worlds/sly1/data/Constants.py
+++ b/worlds/sly1/data/Constants.py
@@ -60,10 +60,10 @@ MOVE_NAMES = [
     "Decoy",
     "Hacking",
     "Progressive Invisibility",
-    "ToT Blueprints",
-    "SSE Blueprints",
-    "VV Blueprints",
-    "FitS Blueprints"
+    "Tide of Terror Blueprints",
+    "Sunset Snake Eyes Blueprints",
+    "Vicious Voodoo Blueprints",
+    "Fire in the Sky Blueprints"
 ]
 
 MOVES = {
@@ -77,10 +77,10 @@ MOVES = {
     "Decoy": 512,
     "Hacking": 2048,
     "Progressive Invisibility": [65536, 8192],
-    "ToT Blueprints": 536870912,
-    "SSE Blueprints": 1073741824,
-    "VV Blueprints": 2147483648,
-    "FitS Blueprints": [0x10000000]
+    "Tide of Terror Blueprints": 536870912,
+    "Sunset Snake Eyes Blueprints": 1073741824,
+    "Vicious Voodoo Blueprints": 2147483648,
+    "Fire in the Sky Blueprints": [0x10000000]
 }
 
 ADDRESSES = {

--- a/worlds/sly1/docs/en_Sly Cooper and the Thievius Raccoonus.md
+++ b/worlds/sly1/docs/en_Sly Cooper and the Thievius Raccoonus.md
@@ -7,11 +7,16 @@ config file.
 
 ## What does randomization do to this game?
 
-Every key, vault, master thief sprint, and episode intro is replaced with an archipelago item.
+Episode access is changed from linear to whenever each "episode unlock" item is received, leading to
+a usually shuffled order of episodes. The goal is always to defeat Clockwerk, but access to his episode
+can be set to be either based on number other bosses beaten, or by collecting an arbitrary number of
+Thievius Raccoonus pages.
 
 ## What items and locations get shuffled?
 
-28 Keys, 19 master thief moves, and 4 episodes can be found at every level end, every time you open the vault, and at every master thief sprint challenge. You can also find some extra 1-ups and charms or various traps.
+Items include 28 keys, all clue bottles, 19 master thief moves, and episode unlock items. You can also be sent filler 1-ups and charms, or various traps.
+Locations are based on the above, and additional locations are enable-able in the YAML, such as including master thief sprints (hourglasses) or adding additional locations
+that get checked when completing minigame levels. This randomizer will also create additional "Key Cache" locations if there are not enough locations to hold required items.
 
 ## Which items can be in another player's world?
 
@@ -20,4 +25,6 @@ certain items to your own world.
 
 ## When the player receives an item, what happens?
 
-You will be able to use the master thief move or open any gate with any keys that you recieve. Murray will always be moved out of the way so you can view any episode but when you recieve an episode as an item, the intro level will be accessible. You may need to view a different episode if you recieve the episode item while viewing said episode.
+You will be able to use the master thief move or open any gate with any keys that you receive.
+Murray will always be moved in front of Cold Heart of Hate so you can view any episode, but access will be restricted until each respective episode unlock item is found, at which point that episode's intro level will be playable.
+You may need to switch view to a different episode if you receive the episode item while viewing said episode.


### PR DESCRIPTION
Finally figured out how to have a proper GitHub setup so that I can make PRs properly :) Didn't want you to have to do a tedious manual review and comparison of things.

This PR adds 19 item groups and 100 location groups which are generated as dynamically as I could get it to be, which required an overhaul of how many items and locations are named, to make that easier to do. I have ensured, to the best of my ability (and with Gehis in the Discord thread doing a successful seed using these changes) that everything works after all of that.

This also includes support for speedrun tricks via a new YAML option.

Finally, I did some improvements onto documentation and wording of things, mostly targeting things that I was personally confused by when first trying out Sly 1 AP. If you'd like a more detailed breakdown of when each change was committed, as well as the release forms I made of the changes, refer to https://github.com/seanstan95/Sly1AP/ which is where I did the changes prior to making this `PhoenixAP` repo.